### PR TITLE
voc_grid: multiple stream support

### DIFF
--- a/software/voc_grid/README.md
+++ b/software/voc_grid/README.md
@@ -8,7 +8,7 @@ Streams are scaled down to thumbnail-like.
 ### Usage
 
 ```bash
-$ ./run.sh (stream|play) stream1 stream2 ...
+$ ./run.sh (stream|play) source1 source2 ...
 ```
 
 The script has two possible modes: stream and play.
@@ -17,6 +17,18 @@ config file.
 In play mode, the grid is shown on the local machine via mpv.
 
 The script is configured via `config.sh`.
+
+Each source can be a HLS stream, a RTMP stream or whatever ffmpeg understands.
+
+You can also append `@<video stream number>:<audio stream number>` to each source
+to select a specific video/audio stream from it (if it contains multiple)
+
+Here's an example:
+
+```
+$ ./run.sh play 'tcp://voctop24.video.fosdem.org:8899@2:1' 'tcp://voctop25.video.fosdem.org:8899@2:1' 'tcp://voctop26.video.fosdem.org:8899@2:1' 'tcp://voctop27.video.fosdem.org:8899@2:1'
+$ # '@2:1' means to select the second video stream (which is 720p) and the first audio stream
+```
 
 ### TODO
 

--- a/software/voc_grid/config.sh
+++ b/software/voc_grid/config.sh
@@ -4,7 +4,7 @@ vid_width=320               # width of each video box
 vid_height=180              # height of each video box
 vol_height=40               # height of vu meter under each video box
 vol_default_num_channels=2  # if video has a different number of channels than specified, it will work fine but will be uglier
-grid_x=4                    # number of horizontal subdivisions
+grid_x=2                    # number of horizontal subdivisions
 grid_y=2                    # number of vertical subdivisions
 # the total number of video boxes is equal to grid_x * grid_y
 


### PR DESCRIPTION
The voc_grid script would break when there is more than one stream in given sources. This PR implements a dirty hack that looks up the number of streams before running ffmpeg/mpv and selects the proper ones.