### PR TITLE
Fix fan PWM algorithm

### DIFF
--- a/hardware/firmware/box_rp2040/src/config.h
+++ b/hardware/firmware/box_rp2040/src/config.h
@@ -115,7 +115,6 @@
 #define PWR_BRD_I2C_BAUD                (10 * 1000)
 #define PWR_BRD_I2C_TIMEOUT_US          20000
 #define PWR_BRD_FAN_CTL_ADDR            0x4d
-
 #define PWR_BRD_TEMP_SENS_ADDR          0x4b
 #define PWR_BRD_EXPANDER_ADDR           0b0100010
 #define PWR_BRD_EXPANDER_PIN_DIRS       0b11111011

--- a/hardware/firmware/box_rp2040/src/io/commands.c
+++ b/hardware/firmware/box_rp2040/src/io/commands.c
@@ -339,7 +339,7 @@ void io_handle_cmd(char* line, io_state_t* state) {
         uint16_t fan_id = parse_number(&line);
         uint16_t speed = parse_number(&line);
 
-        if (fan_ctl_set_fan_speed(fan_id, speed)) {
+        if (fan_ctl_set_fan_speed_target(fan_id, speed)) {
             io_say("ok pb.fan.speed.target\n");
         } else {
             io_say("fail pb.fan.speed.target\n");

--- a/hardware/firmware/box_rp2040/src/io/commands.c
+++ b/hardware/firmware/box_rp2040/src/io/commands.c
@@ -220,8 +220,29 @@ void io_handle_cmd(char* line, io_state_t* state) {
             io_say("loops over all possible i²c addresses and tries to read them\n");
             return;
         }
+
+        io_say("begin pb.i2c.dump_all_regs:\n");
+
+        int16_t reg_values[NUM_I2C_REG];
         uint16_t addr = parse_number(&line);
-        pwr_brd_i2c_dump_all_regs(addr);
+        pwr_brd_i2c_dump_all_regs(reg_values, addr);
+
+        for (uint8_t reg = 0; reg < NUM_I2C_REG; reg++) {
+            io_say("reg ");
+            io_say_uint(reg);
+            io_say(": ");
+
+            if (reg_values[reg] >= 0) {
+                io_say_uint(reg_values[reg]);
+            }
+            else {
+                io_say("fail");
+            }
+
+            io_say("\n");
+        }
+
+        io_say("ok pb.i2c.dump_all_regs\n");
         return;
     }
 

--- a/hardware/firmware/box_rp2040/src/io/commands.c
+++ b/hardware/firmware/box_rp2040/src/io/commands.c
@@ -197,7 +197,20 @@ void io_handle_cmd(char* line, io_state_t* state) {
     }
 
     if (hop_word(&line, "pb.i2c.scan")) {
-        pwr_brd_i2c_bus_scan();
+        io_say("begin pb.i2c.scan:\n");
+
+        bool found[NUM_I2C_ADDR];
+        pwr_brd_i2c_bus_scan(found);
+
+        for (int addr = 0; addr < NUM_I2C_ADDR; ++addr) {
+            if (found[addr]) {
+                io_say("found device at ");
+                io_say_uint(addr);
+                io_say("\n");
+            }
+        }
+
+        io_say("ok pb.i2c.scan\n");
         return;
     }
 

--- a/hardware/firmware/box_rp2040/src/pwr_brd_ctl/fan_ctl.c
+++ b/hardware/firmware/box_rp2040/src/pwr_brd_ctl/fan_ctl.c
@@ -49,6 +49,11 @@ bool fan_ctl_get_fan_speed(uint8_t fan_id, uint16_t* dest) {
         return false;
     }
 
+    if (msb == 0xFF && lsb == 0xF0) {
+        *dest = 0;
+        return true;
+    }
+
     uint16_t tacho = ((msb << 8) | lsb) >> 3;
 
     // To avoid doubles, the fan pole multiplier was multiplied by 2 to make it an integer.

--- a/hardware/firmware/box_rp2040/src/pwr_brd_ctl/fan_ctl.h
+++ b/hardware/firmware/box_rp2040/src/pwr_brd_ctl/fan_ctl.h
@@ -5,7 +5,7 @@
 
 #define FAN_TACH_CONSTANT (7864320)
 #define CMD_WAIT_TIME_US (1000*1000)
-#define DESIRED_RPM (3000)
+#define DESIRED_RPM (5000)
 #define DESIRED_RPM_THRESH (1000)
 #define NUMFAN (5)
 

--- a/hardware/firmware/box_rp2040/src/pwr_brd_ctl/fan_ctl.h
+++ b/hardware/firmware/box_rp2040/src/pwr_brd_ctl/fan_ctl.h
@@ -3,6 +3,12 @@
 #include <stdint.h>
 #include <stdbool.h>
 
+#define FAN_TACH_CONSTANT (7864320)
+#define CMD_WAIT_TIME_US (1000*1000)
+#define DESIRED_RPM (3000)
+#define DESIRED_RPM_THRESH (1000)
+#define NUMFAN (5)
+
 bool fan_ctl_get_fan_speed(uint8_t fan_id, uint16_t* dest);
 bool fan_ctl_get_fan_status(uint8_t* dest);
 bool fan_ctl_get_pwm(uint8_t fan_id, uint8_t* dest);

--- a/hardware/firmware/box_rp2040/src/pwr_brd_ctl/fan_ctl.h
+++ b/hardware/firmware/box_rp2040/src/pwr_brd_ctl/fan_ctl.h
@@ -8,6 +8,7 @@
 #define DESIRED_RPM (5000)
 #define DESIRED_RPM_THRESH (1000)
 #define NUMFAN (5)
+#define FAN_MAX_PWM (10)
 
 bool fan_ctl_get_fan_speed(uint8_t fan_id, uint16_t* dest);
 bool fan_ctl_get_fan_status(uint8_t* dest);

--- a/hardware/firmware/box_rp2040/src/pwr_brd_ctl/fan_ctl.h
+++ b/hardware/firmware/box_rp2040/src/pwr_brd_ctl/fan_ctl.h
@@ -14,3 +14,4 @@ bool fan_ctl_get_fan_status(uint8_t* dest);
 bool fan_ctl_get_pwm(uint8_t fan_id, uint8_t* dest);
 bool fan_ctl_set_pwm(uint8_t fan_id, uint8_t duty);
 bool fan_ctl_set_fan_speed(uint8_t fan_id, uint16_t speed);
+bool fan_ctl_set_fan_speed_target(uint8_t fan_id, uint16_t speed);

--- a/hardware/firmware/box_rp2040/src/pwr_brd_ctl/pwr_brd_ctl.c
+++ b/hardware/firmware/box_rp2040/src/pwr_brd_ctl/pwr_brd_ctl.c
@@ -110,20 +110,14 @@ void pwr_brd_i2c_bus_scan(bool found[NUM_I2C_ADDR]) {
     }
 }
 
-void pwr_brd_i2c_dump_all_regs(uint8_t addr) {
-    io_say("begin pb.i2c.dump_all_regs:\n");
+void pwr_brd_i2c_dump_all_regs(int16_t reg_values[NUM_I2C_REG], uint8_t addr) {
+    for (uint8_t reg = 0; reg < NUM_I2C_REG; reg++) {
+        uint8_t val;
 
-    for (uint8_t reg = 0x0; reg < 0xfe; reg++) {
-        uint8_t val = 0;
-        io_say("reg ");
-        io_say_uint(reg);
-        io_say(": ");
-        if(pwr_brd_i2c_read_reg(addr, reg, &val, 1)) {
-            io_say_uint(val);
+        if (pwr_brd_i2c_read_reg(addr, reg, &val, 1)) {
+            reg_values[reg] = val;
         } else {
-            io_say("fail");
+            reg_values[reg] = PICO_ERROR_GENERIC;
         }
-        io_say("\n");
     }
-    io_say("ok pb.i2c.dump_all_regs\n");
 }

--- a/hardware/firmware/box_rp2040/src/pwr_brd_ctl/pwr_brd_ctl.c
+++ b/hardware/firmware/box_rp2040/src/pwr_brd_ctl/pwr_brd_ctl.c
@@ -90,10 +90,8 @@ bool pwr_brd_i2c_write_reg(uint8_t dev_addr, uint8_t reg_id, uint8_t* src, uint8
     return true;
 }
 
-void pwr_brd_i2c_bus_scan() {
-    io_say("begin pb.i2c.scan:\n");
-
-    for (int addr = 0; addr < (1 << 7); ++addr) {
+void pwr_brd_i2c_bus_scan(bool found[NUM_I2C_ADDR]) {
+    for (int addr = 0; addr < NUM_I2C_ADDR; ++addr) {
         // Perform a 1-byte dummy read from the probe address. If a slave
         // acknowledges this address, the function returns the number of bytes
         // transferred. If the address byte is ignored, the function returns
@@ -108,13 +106,8 @@ void pwr_brd_i2c_bus_scan() {
             ret = i2c_read_blocking_until(PWR_BRD_I2C_INST, addr, &rxdata, 1, false, make_timeout_time_ms(20));
         }
 
-        if (ret >= 0) {
-            io_say("found device at ");
-            io_say_uint(addr);
-            io_say("\n");
-        }
+        found[addr] = ret >= 0;
     }
-    io_say("ok pb.i2c.scan\n");
 }
 
 void pwr_brd_i2c_dump_all_regs(uint8_t addr) {

--- a/hardware/firmware/box_rp2040/src/pwr_brd_ctl/pwr_brd_ctl.h
+++ b/hardware/firmware/box_rp2040/src/pwr_brd_ctl/pwr_brd_ctl.h
@@ -8,13 +8,14 @@
 #define DESIRED_RPM (3000)
 #define DESIRED_RPM_THRESH (1000)
 #define NUMFAN (5)
+#define NUM_I2C_ADDR (1 << 7)
 
 
 void pwr_brd_ctl_init();
 void pwr_brd_fan_task();
 void pwr_brd_fan_init();
 bool pwr_brd_raw_gpio_read(uint8_t* val);
-void pwr_brd_i2c_bus_scan();
+void pwr_brd_i2c_bus_scan(bool found[NUM_I2C_ADDR]);
 void pwr_brd_i2c_dump_all_regs(uint8_t addr);
 bool temp_sensor_get_temp_raw(uint8_t* dest);
 bool pwr_brd_i2c_read_reg(uint8_t dev_addr, uint8_t reg_id, uint8_t* dest, uint8_t num_bytes);

--- a/hardware/firmware/box_rp2040/src/pwr_brd_ctl/pwr_brd_ctl.h
+++ b/hardware/firmware/box_rp2040/src/pwr_brd_ctl/pwr_brd_ctl.h
@@ -9,6 +9,7 @@
 #define DESIRED_RPM_THRESH (1000)
 #define NUMFAN (5)
 #define NUM_I2C_ADDR (1 << 7)
+#define NUM_I2C_REG (0xfe)
 
 
 void pwr_brd_ctl_init();
@@ -16,7 +17,7 @@ void pwr_brd_fan_task();
 void pwr_brd_fan_init();
 bool pwr_brd_raw_gpio_read(uint8_t* val);
 void pwr_brd_i2c_bus_scan(bool found[NUM_I2C_ADDR]);
-void pwr_brd_i2c_dump_all_regs(uint8_t addr);
+void pwr_brd_i2c_dump_all_regs(int16_t reg_values[NUM_I2C_REG], uint8_t addr);
 bool temp_sensor_get_temp_raw(uint8_t* dest);
 bool pwr_brd_i2c_read_reg(uint8_t dev_addr, uint8_t reg_id, uint8_t* dest, uint8_t num_bytes);
 bool pwr_brd_i2c_write_reg(uint8_t dev_addr, uint8_t reg_id, uint8_t* src, uint8_t num_bytes);

--- a/hardware/firmware/box_rp2040/src/pwr_brd_ctl/pwr_brd_ctl.h
+++ b/hardware/firmware/box_rp2040/src/pwr_brd_ctl/pwr_brd_ctl.h
@@ -3,14 +3,8 @@
 #include <stdbool.h>
 #include <stdint.h>
 
-#define FAN_WAIT_LOOPS (1000)
-#define CMD_WAIT_TIME_US (1000*1000)
-#define DESIRED_RPM (3000)
-#define DESIRED_RPM_THRESH (1000)
-#define NUMFAN (5)
 #define NUM_I2C_ADDR (1 << 7)
 #define NUM_I2C_REG (0xfe)
-
 
 void pwr_brd_ctl_init();
 void pwr_brd_fan_task();


### PR DESCRIPTION
- Move 2 debugging functions to commands.c, to get acquainted to the codebase
- cleanup fan_ctl, move constants to the relevant files
- bring back the original fan_set_speed function for reference
- increase max RPM because the current one is very close to the PWM minumum value cutoff
- add edge case for zero RPM/fan unplugged using the raw values
- rework the fan control algorithm so it's easier to understand