### PR TITLE
Fan fixes

### DIFF
--- a/hardware/firmware/box_rp2040/flash.sh
+++ b/hardware/firmware/box_rp2040/flash.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -euo pipefail
+
+cdir="$(dirname "$(readlink -f "${0}")")"
+
+echo "Building firmware..."
+"${cdir}"/build.sh
+
+echo "Flashing firmware..."
+"$cdir"/../tools/flash_rp2040_firmware.sh "$cdir"/build/src/box_rp2040.elf

--- a/hardware/firmware/box_rp2040/src/pwr_brd_ctl/fan_ctl.h
+++ b/hardware/firmware/box_rp2040/src/pwr_brd_ctl/fan_ctl.h
@@ -5,13 +5,16 @@
 
 #define FAN_TACH_CONSTANT (7864320)
 #define CMD_WAIT_TIME_US (3000 * 1000)
-#define DESIRED_RPM (5000)
+#define DESIRED_RPM (1)
 #define DESIRED_RPM_THRESH_UPPER (1000)
 #define DESIRED_RPM_THRESH_LOWER (2000)
 #define FAN_MIN_HEALTHY_RPM (3000)
 #define FAN_MAX_HEALTHY_RPM (10000)
 #define NUMFAN (5)
-#define FAN_MAX_PWM (10)
+#define FAN_MAX_PWM (6)
+
+#define FAN_STATE_CALIBRATE (0)
+#define FAN_STATE_RUN (1)
 
 bool fan_ctl_get_fan_speed(uint8_t fan_id, uint16_t* dest);
 bool fan_ctl_get_fan_status(uint8_t* dest);


### PR DESCRIPTION
Replace the fan control system... again...

This runs a calibration step on bootup to store the fancurve of all connected fans, then simply keep the PWM at a fixed requested level so it won't do random rpm-measurement based spinups.

It changes the behavior of `desired_fan_speed[fan]` to be PWM levels above stall speed. So 0=off, 1=quiet, 2=loud. On stall the fan will be run at high speed for a second and then return to the requested speed setting.

The `fan_error[fan]` array keeps track of disconnected fans on startup.