### PR TITLE
Implement basic VLAN support for the FOSDEM switch

### DIFF
--- a/hardware/firmware/box_rp2040/src/network_switch/README.md
+++ b/hardware/firmware/box_rp2040/src/network_switch/README.md
@@ -1,0 +1,56 @@
+# RTL8723S api
+
+The VLAN handling is processed by two tables. The VLAN table has 4096 entries and is
+used for processing incoming traffic with a vlan tag set and defines which ports
+are part of that specific VLAN and which ports should have the tag stripped on
+egress.
+
+The second table is the MemberConfig table. this only has 16 rows and is for
+matching all the incoming untagged traffic. Each port can be assigned to a
+MemberConfig entry which will assign the incoming packets a VLAN tag before
+it is processed through the main VLAN handling table.
+
+All the port lists are bitfields that refer to the PHY IDs of the switch ports.
+These IDs are printed on the PCB silkscreen near every transformer with
+the `PHY%` label.
+
+| PHY  | Port                  |
+|------|-----------------------|
+| PHY0 | Port facing the Radxa |
+| PHY1 | Port 4 on the outside |
+| PHY2 | Port 3 on the outside |
+| PHY3 | Port 2 on the outside |
+| PHY4 | Port 1 on the outside |
+
+```c
+// Set the MemberConfig for all ports to 0 and enable tag handling on the ports
+nsw_vlan_init();
+
+// Enable the VLAN processing in the switch
+nsw_config_vlans(true);
+
+// Create a VLAN table entry for VLAN 10 with port 1, 2 and 3 as members
+// Port 2 and 3 will be untagged on egress
+nsw_vlan_cfg_t vlan10 = {
+		.vid = 10,
+		.mbr = BIT(0) | BIT(1) | BIT(2),
+		.untag = BIT(1) | BIT(2),
+};
+nsw_vlan_set(&vlan10);
+
+// Create a MemberConfig row to ingress untagged traffic on port 2 and 3
+// Use MemberConfig index 1 and vlan 10
+nsw_mc_set(1, 10, BIT(1) | BIT(2));
+
+// Point the two untagged ports to MemberConfig index 1. This needs to
+// happen _after_ setting the ports as member in the MemberConfig itself
+nsw_port_set_mc(1, 1);
+nsw_port_set_mc(1, 2);
+
+// Set the untagged ports to drop traffic with a vlan tag set
+nsw_port_vlan_filtering(1, PORT_ACCEPT_UNTAGGED_ONLY);
+nsw_port_vlan_filtering(2, PORT_ACCEPT_UNTAGGED_ONLY);
+
+// Drop untagged traffic from the trunk port
+nsw_port_vlan_filtering(2, PORT_ACCEPT_TAGGED_ONLY);
+```

--- a/hardware/firmware/box_rp2040/src/network_switch/network_switch_status_reader.c
+++ b/hardware/firmware/box_rp2040/src/network_switch/network_switch_status_reader.c
@@ -101,11 +101,38 @@
 #define REG_PHY_BASE 0x2000
 #define REG_PHY_OCP_ADDR_PHYREG_BASE 0xA400
 
+#define REG_PORT_MISC_CFG_BASE 0x000e
+#define REG_PORT_MISC_CFG(port) (REG_PORT_MISC_CFG_BASE + (port << 5))
+#define REG_TABLE_ACCESS_CONTROL 0x0500
+#define REG_TABLE_ACCESS_ADDR 0x0501
+#define REG_TABLE_ACCESS_STATUS 0x0502
+#define REG_TABLE_RD_BASE 0x0520
+#define REG_TABLE_WD_BASE 0x0510
+#define REG_VLAN_PVID_BASE 0x0700
+#define REG_VLAN_PVID(port) (REG_VLAN_PVID_BASE + (port >> 1))
+#define REG_MC_BASE 0x0728
+#define REG_VLAN_CONTROL 0x07a8
+#define REG_VLAN_ACCEPT_FRAME_TYPE_BASE 0x07aa
+#define REG_VLAN_ACCEPT_FRAME_TYPE(port) (REG_VLAN_ACCEPT_FRAME_TYPE_BASE + (port >> 3))
+#define MASK_VLAN_ACCEPT_FRAME_TYPE(port) (3 << ((port & 0x07) << 1))
+#define MASK_TABLE_TYPE 0x07
+#define MASK_CMD_TYPE 0x08
+#define OFFSET_TABLE_ACCESS(op, target) ((op << 3) | target)
+#define TABLE_OP_READ 0
+#define TABLE_OP_WRITE 1
+#define TABLE_ACLRULE 1
+#define TABLE_ACLACT 2
+#define TABLE_CVLAN 3
+#define TABLE_L2 4
+#define TABLE_IGMP 5
+
+#define NUM_PORTS 5
+
 /* Code from https://github.com/McMCCRU/Arduino_RTL8367C/blob/master/rtl8367c.ino for SMI access*/
 
-#define CLK_DURATION(clk)	sleep_us(clk)
-#define DELAY			3
-#define ack_timer		10
+#define CLK_DURATION(clk)    sleep_us(clk)
+#define DELAY            3
+#define ack_timer        10
 
 /* smi */
 void _smi_start()
@@ -332,13 +359,58 @@ bool smi_read_port(int port, int reg, uint32_t* buf) {
     return smi_read(0x1f04, buf);
 }
 
-void nsw_init(void) {
+bool
+smi_update_bits(int reg, uint32_t mask, uint32_t val) {
+    uint32_t orig, tmp;
+
+    if (!smi_read(reg, &orig)) { return false; }
+
+    tmp = orig & ~mask;
+    tmp |= val & mask;
+
+    return smi_write(reg, tmp);
+}
+
+/*
+uint64_t smi_read_mib_counter(int port, int offset, int length) {
+    // Request MIB read
+    int addr = ((0x7C * port) + offset) >> 2;
+    smi_write(REG_MIB_ADDRESS, addr);
+
+    // Poll for completion
+    while (1) {
+        uint32_t status = smi_read(REG_MIB_CTRL0);
+        if (status & REG_MIB_CTRL0) {
+            sleep_ms(3);
+        } else {
+            break;
+        }
+    }
+
+    if (length == 4) {
+        offset = 3;
+    } else {
+        offset = (offset + 1) % 4;
+    }
+    uint64_t result = 0;
+    for (int i = 0; i < length; i++) {
+        int counter_reg = 0x1000 + (offset - i);
+        uint32_t val = smi_read(counter_reg);
+        result = ((result) << 16) | (val & 0xFFFF);
+    }
+    return result;
+}
+*/
+
+void
+nsw_init(void) {
     gpio_init(NSW_PIN_DAT);
     gpio_init(NSW_PIN_CLK);
     gpio_disable_pulls(NSW_PIN_DAT);
 }
 
-bool nsw_identify(uint32_t* id, uint32_t* ver) {
+bool
+nsw_identify(uint32_t *id, uint32_t *ver) {
     // https://github.com/torvalds/linux/blob/7e90b5c295ec1e47c8ad865429f046970c549a66/drivers/net/dsa/realtek/rtl8365mb.c#L2045
     if (!smi_write(REG_MAGIC, REG_MAGIC_VAL)) { return false; }
     if (!smi_read(REG_CHIP_ID, id)) { return false; }
@@ -347,25 +419,196 @@ bool nsw_identify(uint32_t* id, uint32_t* ver) {
     return true;
 }
 
-bool nsw_read_port_regs(uint8_t port, nsw_port_regs_t* regs) {
-    if (!smi_read_port(port, MII_BMCR, &regs->bmcr))  { return false; }
-    if (!smi_read_port(port, MII_BMSR, &regs->bmsr))  { return false; }
-    if (!smi_read_port(port, MII_AN,   &regs->an))    { return false; }
-    if (!smi_read_port(port, MII_LPA,  &regs->lpa))   { return false; }
-    if (!smi_read_port(port, MII_GBEC, &regs->gbec))  { return false; }
-    if (!smi_read_port(port, MII_GBES, &regs->gbes))  { return false; }
+bool
+nsw_vlan_get(vlan_id_t vid, nsw_vlan_cfg_t *cfg) {
+    uint32_t tmp;
+    if (vid > 4095)
+        return false;
+
+    if (cfg == NULL)
+        return false;
+
+    int busycounter = 10;
+    while (busycounter-- > 0) {
+        if (!smi_read(REG_TABLE_ACCESS_STATUS, &tmp))
+            return false;
+        if ((tmp & (1 << 13)) == 0) {
+            break;
+        }
+    }
+
+    // Write address
+    if (!smi_write(REG_TABLE_ACCESS_ADDR, vid))
+        return false;
+
+    // Write command
+    if (!smi_update_bits(REG_TABLE_ACCESS_CONTROL, MASK_CMD_TYPE | MASK_TABLE_TYPE,
+                         OFFSET_TABLE_ACCESS(TABLE_OP_READ, TABLE_CVLAN)))
+        return false;
+
+    // Busy poll
+    busycounter = 10;
+    while (busycounter-- > 0) {
+        if (!smi_read(REG_TABLE_ACCESS_STATUS, &tmp))
+            return false;
+        if ((tmp & (1 << 13)) == 0) {
+            break;
+        }
+    }
+
+    // Read table row
+    uint32_t raw[3] = {0};
+    for (int i = 0; i < 3; i++) {
+        smi_read(0x0520, &raw[i]);
+    }
+
+    // Parse row
+    cfg->mbr = raw[0] & 0xFF;
+    cfg->untag = (raw[0] >> 8) & 0xFF;
+
     return true;
 }
 
-nsw_link_state_t nsw_link_state(nsw_port_regs_t* regs) {
+bool
+nsw_vlan_set(nsw_vlan_cfg_t *cfg) {
+    uint32_t data[3];
+    vlan_id_t vid = cfg->vid;
+
+    if (vid > 4095)
+        return false;
+
+    if (cfg == NULL)
+        return false;
+
+    //data[0] = (cfg->vid & 0xFFF);
+    data[0] = (cfg->mbr & 0xFF) | ((cfg->untag & 0xFF) << 8);
+    data[1] = 0;
+    data[2] = 0;
+
+    for (int i = 0; i < 3; i++) {
+        if (!smi_write(REG_TABLE_WD_BASE + i, data[i]))
+            return false;
+    }
+
+    if (!smi_write(REG_TABLE_ACCESS_ADDR, (uint32_t) cfg->vid))
+        return false;
+
+
+    // Write command
+    if (!smi_update_bits(REG_TABLE_ACCESS_CONTROL, MASK_CMD_TYPE | MASK_TABLE_TYPE,
+                         OFFSET_TABLE_ACCESS(TABLE_OP_WRITE, TABLE_CVLAN)))
+        return false;
+
+    return true;
+}
+
+bool
+nsw_mc_set(int mcindex, vlan_id_t vid, uint32_t members) {
+    uint32_t row[4];
+
+    row[0] = members & 0x07ff;
+    row[1] = 0;
+    row[2] = 0;
+    row[3] = vid & 0x1fff;
+
+    for (int i = 0; i < 4; i++) {
+        if (!smi_write(REG_MC_BASE + (mcindex * 4) + i, row[i]))
+            return false;
+    }
+
+    return true;
+}
+
+bool
+nsw_mc_get(int mcindex, nsw_mc_cfg_t *cfg) {
+    uint32_t row[4];
+    for (int i = 0; i < 4; i++) {
+        if (!smi_read(REG_MC_BASE + (mcindex * 4) + i, &row[i]))
+            return false;
+    }
+
+    cfg->mbr = row[0] & 0x07FF;
+    cfg->vid = row[3] & 0x1FFF;
+
+    return true;
+}
+
+void
+nsw_dump_vlan_table() {
+    nsw_vlan_cfg_t cfg;
+    io_say_f("vlan table:\r\n");
+    for (uint32_t i = 0; i < 4095; i++) {
+        nsw_vlan_get(i, &cfg);
+        if (cfg.mbr) {
+            io_say_f("VLAN %04lu  ", i);
+            for (uint j = 0; j < NUM_PORTS; j++) {
+                if (cfg.mbr & (1 << j)) {
+                    io_say_f("%d ", j);
+                }
+            }
+            io_say_f("\r\n");
+        }
+    }
+}
+
+void
+nsw_dump_member_config() {
+    nsw_mc_cfg_t cfg;
+    for (int i = 0; i < 16; i++) {
+        nsw_mc_get(i, &cfg);
+
+        io_say_f("MC %02d vid %04d mbr ", i, cfg.vid, cfg.mbr);
+        for (uint j = 0; j < NUM_PORTS; j++) {
+            if (cfg.mbr & (1 << j)) {
+                io_say_f("%d ", j);
+            }
+        }
+        io_say_f("\r\n");
+    }
+}
+
+void
+nsw_vlan_init() {
+    for (int i = 0; i < NUM_PORTS; i++) {
+        nsw_port_set_mc(i, 0);
+		nsw_port_set_tagmode(i, PORT_TAGMODE_ORIGINAL);
+    }
+}
+
+void
+nsw_dump_pvids() {
+    uint32_t tmp;
+    for (int i = 0; i < NUM_PORTS; i++) {
+        smi_read(REG_VLAN_PVID(i), &tmp);
+        if (i % 2 == 1) {
+            io_say_f("Port %d pvid %lu\r\n", i, tmp >> 8);
+        } else {
+            io_say_f("Port %d pvid %lu\r\n", i, tmp & 0xFF);
+        }
+    }
+}
+
+bool
+nsw_read_port_regs(uint8_t port, nsw_port_regs_t *regs) {
+    if (!smi_read_port(port, MII_BMCR, &regs->bmcr)) { return false; }
+    if (!smi_read_port(port, MII_BMSR, &regs->bmsr)) { return false; }
+    if (!smi_read_port(port, MII_AN, &regs->an)) { return false; }
+    if (!smi_read_port(port, MII_LPA, &regs->lpa)) { return false; }
+    if (!smi_read_port(port, MII_GBEC, &regs->gbec)) { return false; }
+    if (!smi_read_port(port, MII_GBES, &regs->gbes)) { return false; }
+    return true;
+}
+
+nsw_link_state_t
+nsw_link_state(nsw_port_regs_t *regs) {
     // https://github.com/torvalds/linux/blob/master/drivers/net/mii.c
-    if(regs->bmcr & MII_BMCR_AUTONEG_ENABLE) {
-        if(regs->bmsr & MII_BMSR_AUTONEG_COMPLETE) {
+    if (regs->bmcr & MII_BMCR_AUTONEG_ENABLE) {
+        if (regs->bmsr & MII_BMSR_AUTONEG_COMPLETE) {
             if ((regs->gbes & MII_GBES_1000BaseTFD) && (regs->gbec & MII_GBEC_1000BaseTFD)) {
                 return nsw_link_full_duplex;
             } else if ((regs->gbes & MII_GBES_1000BaseTHD) && (regs->gbec & MII_GBEC_1000BaseTHD)) {
                 return nsw_link_half_duplex;
-            } else if ( (regs->lpa & MII_LPA_100BaseTXFD) && (regs->an & MII_AN_100BaseTXFD )) {
+            } else if ((regs->lpa & MII_LPA_100BaseTXFD) && (regs->an & MII_AN_100BaseTXFD)) {
                 return nsw_link_full_duplex;
             } else if ((regs->lpa & MII_LPA_100BaseTXHD) && (regs->an & MII_AN_100BaseTXHD)) {
                 return nsw_link_half_duplex;
@@ -380,15 +623,48 @@ nsw_link_state_t nsw_link_state(nsw_port_regs_t* regs) {
     } else {
         return nsw_link_unknown;
     }
+    return nsw_link_unknown;
 }
 
-uint16_t nsw_link_speed_mbps(nsw_port_regs_t* regs) {
+bool
+nsw_port_set_mc(int port, int mcindex) {
+    uint32_t mask = 0xFF;
+    if (port & 1) {
+        mcindex = mcindex << 8;
+        mask = mask << 8;
+    }
+    return smi_update_bits(REG_VLAN_PVID(port), mask, mcindex);
+}
+
+bool
+nsw_port_set_tagmode(int port, tagmode_t tagmode) {
+    return smi_update_bits(REG_PORT_MISC_CFG(port), 0x30, tagmode << 4);
+}
+
+bool
+nsw_port_vlan_filtering(int port, vlan_port_filter_t filtering) {
+    // 0 = Accept both tagged and untagged
+    // 1 = Accept tagged only
+    // 2 = Accept untagged only
+    uint32_t mask = 0x07 << MASK_VLAN_ACCEPT_FRAME_TYPE(port);
+    uint32_t shifted = filtering << (port << 1);
+    return smi_update_bits(REG_VLAN_ACCEPT_FRAME_TYPE(port), mask, shifted);
+}
+
+bool
+nsw_config_vlans(bool enable) {
+    smi_update_bits(REG_VLAN_CONTROL, 1, enable ? 1 : 0);
+    return true;
+}
+
+uint16_t
+nsw_link_speed_mbps(nsw_port_regs_t *regs) {
     if ((regs->bmcr & MII_BMCR_AUTONEG_ENABLE) && (regs->bmsr & MII_BMSR_AUTONEG_COMPLETE)) {
         if ((regs->gbes & MII_GBES_1000BaseTFD) && (regs->gbec & MII_GBEC_1000BaseTFD)) {
             return 1000;
         } else if ((regs->gbes & MII_GBES_1000BaseTHD) && (regs->gbec & MII_GBEC_1000BaseTHD)) {
             return 1000;
-        } else if ( (regs->lpa & MII_LPA_100BaseTXFD) && (regs->an & MII_AN_100BaseTXFD )) {
+        } else if ((regs->lpa & MII_LPA_100BaseTXFD) && (regs->an & MII_AN_100BaseTXFD)) {
             return 100;
         } else if ((regs->lpa & MII_LPA_100BaseTXHD) && (regs->an & MII_AN_100BaseTXHD)) {
             return 100;

--- a/hardware/firmware/box_rp2040/src/network_switch/network_switch_status_reader.h
+++ b/hardware/firmware/box_rp2040/src/network_switch/network_switch_status_reader.h
@@ -19,8 +19,54 @@ typedef enum {
     nsw_link_half_duplex
 } nsw_link_state_t;
 
+typedef uint16_t vlan_id_t;
+
+typedef struct {
+	vlan_id_t vid;
+	uint16_t mbr;
+	uint16_t untag;
+	uint16_t ivl_en;
+	uint16_t fid_msti;
+	uint16_t envlanpol;
+	uint16_t meteridx;
+	uint16_t vbpen;
+	uint16_t vbpri;
+} nsw_vlan_cfg_t;
+
+typedef struct {
+	uint16_t index;
+	vlan_id_t vid;
+	uint16_t mbr;
+} nsw_mc_cfg_t;
+
 void nsw_init(void);
 bool nsw_identify(uint32_t* id, uint32_t* ver);
 bool nsw_read_port_regs(uint8_t port, nsw_port_regs_t* regs);
 nsw_link_state_t nsw_link_state(nsw_port_regs_t* regs);
 uint16_t nsw_link_speed_mbps(nsw_port_regs_t* regs);
+void nsw_dump_vlan_table();
+void nsw_dump_member_config();
+void nsw_dump_pvids();
+
+bool nsw_config_vlans(bool enable);
+bool nsw_vlan_set(nsw_vlan_cfg_t *cfg);
+bool nsw_vlan_get(vlan_id_t vid, nsw_vlan_cfg_t *cfg);
+
+typedef enum vlan_port_filter {
+	PORT_ACCEPT_ALL = 0,
+	PORT_ACCEPT_TAGGED_ONLY = 1,
+	PORT_ACCEPT_UNTAGGED_ONLY = 2,
+} vlan_port_filter_t;
+bool nsw_port_vlan_filtering(int port, vlan_port_filter_t filtering);
+bool nsw_mc_set(int mcindex, vlan_id_t vid, uint32_t members);
+bool nsw_port_set_mc(int port, int mcindex);
+
+typedef enum tagmode {
+	PORT_TAGMODE_ORIGINAL = 0,
+	PORT_TAGMODE_KEEP_FORMAT,
+	PORT_TAGMODE_REAL_KEEP_FORMAT,
+	PORT_TAGMODE_PRI,
+} tagmode_t;
+bool nsw_port_set_tagmode(int port, tagmode_t tagmode);
+
+void nsw_vlan_init();


### PR DESCRIPTION
The VLAN handling is processed by two tables. The VLAN table has 4096 entries and is
used for processing incoming traffic with a vlan tag set and defines which ports
are part of that specific VLAN and which ports should have the tag stripped on
egress.

The second table is the MemberConfig table. this only has 16 rows and is for
matching all the incoming untagged traffic. Each port can be assigned to a
MemberConfig entry which will assign the incoming packets a VLAN tag before
it is processed through the main VLAN handling table.

All the port lists are bitfields that refer to the PHY IDs of the switch ports.
These IDs are printed on the PCB silkscreen near every transformer with
the `PHY%` label.

| PHY  | Port                  |
|------|-----------------------|
| PHY0 | Port facing the Radxa |
| PHY1 | Port 4 on the outside |
| PHY2 | Port 3 on the outside |
| PHY3 | Port 2 on the outside |
| PHY4 | Port 1 on the outside |

```c
// Set the MemberConfig for all ports to 0 and enable tag handling on the ports
nsw_vlan_init();

// Enable the VLAN processing in the switch
nsw_config_vlans(true);

// Create a VLAN table entry for VLAN 10 with port 1, 2 and 3 as members
// Port 2 and 3 will be untagged on egress
nsw_vlan_cfg_t vlan10 = {
		.vid = 10,
		.mbr = BIT(0) | BIT(1) | BIT(2),
		.untag = BIT(1) | BIT(2),
};
nsw_vlan_set(&vlan10);

// Create a MemberConfig row to ingress untagged traffic on port 2 and 3
// Use MemberConfig index 1 and vlan 10
nsw_mc_set(1, 10, BIT(1) | BIT(2));

// Point the two untagged ports to MemberConfig index 1. This needs to
// happen _after_ setting the ports as member in the MemberConfig itself
nsw_port_set_mc(1, 1);
nsw_port_set_mc(1, 2);

// Set the untagged ports to drop traffic with a vlan tag set
nsw_port_vlan_filtering(1, PORT_ACCEPT_UNTAGGED_ONLY);
nsw_port_vlan_filtering(2, PORT_ACCEPT_UNTAGGED_ONLY);

// Drop untagged traffic from the trunk port
nsw_port_vlan_filtering(2, PORT_ACCEPT_TAGGED_ONLY);
```