### PR TITLE
fix: the wav file playback driver copies chunk data ... in...

### DIFF
--- a/hardware/firmware/audio_board/vendor/Audio/play_sd_wav.cpp
+++ b/hardware/firmware/audio_board/vendor/Audio/play_sd_wav.cpp
@@ -251,6 +251,7 @@ start:
 	  case STATE_PARSE1:
 		len = data_length;
 		if (size < len) len = size;
+		if (header_offset + len > sizeof(header)) len = sizeof(header) - header_offset;
 		memcpy((uint8_t *)header + header_offset, p, len);
 		header_offset += len;
 		buffer_offset += len;


### PR DESCRIPTION
## Summary
Fix high severity security issue in `hardware/firmware/audio_board/vendor/Audio/play_sd_wav.cpp`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-004 |
| **Severity** | HIGH |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-004` |
| **File** | `hardware/firmware/audio_board/vendor/Audio/play_sd_wav.cpp:254` |

**Description**: The WAV file playback driver copies chunk data into a fixed-size header buffer using an offset and length derived directly from the WAV file's chunk headers, without validating that header_offset + len stays within the buffer boundary. A maliciously crafted WAV file placed on the SD card can specify a chunk length that causes the memcpy to write beyond the header buffer, corrupting adjacent memory on the audio microcontroller. This affects any device that plays WAV files from an SD card.

## Changes
- `hardware/firmware/audio_board/vendor/Audio/play_sd_wav.cpp`

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
