### PR TITLE
Implement network switch vlan configuration over the serial port

### DIFF
--- a/hardware/firmware/box_rp2040/src/io/commands.c
+++ b/hardware/firmware/box_rp2040/src/io/commands.c
@@ -13,30 +13,49 @@
 #include <stdbool.h>
 #include <stdint.h>
 
+#include "../network_switch/network_switch_status_reader.h"
+
 void help(void) {
     io_say("available commands:\n");
-    io_say("    netswitch.info          -- respond with network switch info\n");
-    io_say("    display.text.line       -- show text on the display\n");
-    io_say("    display.text.clear      -- clear text shown on display\n");
-    io_say("    display.img             -- display an image\n");
-    io_say("    display.img.clear       -- clear image(s) shown on display\n");
-    io_say("    display.refresh         -- commit all previously called display commands\n");
-    io_say("    display.imgonly         -- like display.refresh, but hides all text. very fast.\n");
-    io_say("    pb.gpio.read.raw        -- read raw GPIO status on the power board\n");
-    io_say("    pb.temp.raw             -- show raw power board temperature reading\n");
-    io_say("    pb.chargers.on          -- turn chargers on or off\n");
-    io_say("    pb.i2c.scan             -- scan for devices on the power board i²c bus\n");
-    io_say("    pb.i2c.dump_all_regs    -- try to dump all registers of an i²c device\n");
-    io_say("    pb.fan.status           -- get a magic number whose bits encode fan statuses\n");
-    io_say("    pb.fan.speed.get        -- get fan speed\n");
-    io_say("    pb.fan.speed.target     -- set fan speed\n");
-    io_say("    pb.fan.pwm              -- get fan pwm duty cycle\n");
-    io_say("    pb.fan.pwm.force        -- force fan into raw pwm mode\n");
-    io_say("    bootloader              -- reboot into bootloader\n");
-    io_say("    status                  -- general human-readable status\n");
+    io_say("    netswitch.info               -- respond with network switch info\n");
+    io_say("    netswitch.vlans              -- respond with switch vlan info\n");
+    io_say("    netswitch.vlan-member-define -- store a new vlan table entry\n");
+    io_say("    netswitch.vlan-member-define -- store a new vlan memberconfig\n");
+    io_say("    netswitch.vlan-filtering     -- set vlan filter mode for port\n");
+    io_say("    display.text.line            -- show text on the display\n");
+    io_say("    display.text.clear           -- clear text shown on display\n");
+    io_say("    display.img                  -- display an image\n");
+    io_say("    display.img.clear            -- clear image(s) shown on display\n");
+    io_say("    display.refresh              -- commit all previously called display commands\n");
+    io_say("    display.imgonly              -- like display.refresh, but hides all text. very fast.\n");
+    io_say("    pb.gpio.read.raw             -- read raw GPIO status on the power board\n");
+    io_say("    pb.temp.raw                  -- show raw power board temperature reading\n");
+    io_say("    pb.chargers.on               -- turn chargers on or off\n");
+    io_say("    pb.i2c.scan                  -- scan for devices on the power board i²c bus\n");
+    io_say("    pb.i2c.dump_all_regs         -- try to dump all registers of an i²c device\n");
+    io_say("    pb.fan.status                -- get a magic number whose bits encode fan statuses\n");
+    io_say("    pb.fan.speed.get             -- get fan speed\n");
+    io_say("    pb.fan.speed.target          -- set fan speed\n");
+    io_say("    pb.fan.pwm                   -- get fan pwm duty cycle\n");
+    io_say("    pb.fan.pwm.force             -- force fan into raw pwm mode\n");
+    io_say("    bootloader                   -- reboot into bootloader\n");
+    io_say("    status                       -- general human-readable status\n");
     io_say("call a command without arguments for usage\n");
     io_say("every command's output ends with '^(ok|fail) .*\\n'\n");
     io_say("ok help\n");
+}
+
+void io_print_netswitch_vlans(void)
+{
+    if (nsw_config_is_vlans_enabled())
+    {
+        io_say("vlan support is enabled\n");
+        nsw_dump_vlan_table();
+        nsw_dump_member_config();
+    } else
+    {
+        io_say("vlans are disabled\n");
+    }
 }
 
 bool io_print_netswitch_port_info(void) {
@@ -181,6 +200,94 @@ void io_handle_cmd(char* line, io_state_t* state) {
             io_say("fail netswitch.info\n");
             return;
         }
+        return;
+    }
+
+    if (hop_word(&line, "netswitch.vlans")) {
+        io_print_netswitch_vlans();
+        io_say("ok netswitch.vlans\n");
+        return;
+    }
+
+    if (hop_word(&line, "netswitch.vlan-init")) {
+        if (line[0] == '\0') {
+            io_say("usage: netswitch.vlan-init <enable>\n");
+            io_say("enable or disable vlan support and clear the table\n");
+            return;
+        }
+        uint16_t enable = parse_number(&line);
+        if (enable) {
+            nsw_vlan_init();
+            nsw_config_vlans(true);
+        }
+        else {
+            nsw_config_vlans(false);
+        }
+
+        io_say("ok netswitch.vlan-init\n");
+        return;
+    }
+
+    if (hop_word(&line, "netswitch.vlan-entry-define")) {
+        if (line[0] == '\0') {
+            io_say("usage: netswitch.vlan-entry-define <vid> <members> <untagged>\n");
+            io_say("define an entry in the vlan table\n");
+            return;
+        }
+        uint16_t vid = parse_number(&line);
+        uint16_t members = parse_number(&line);
+        uint16_t untagged = parse_number(&line);
+
+        nsw_vlan_cfg_t entry = {
+            .vid = vid,
+            .mbr = members,
+            .untag = untagged,
+        };
+        nsw_vlan_set(&entry);
+        io_say("ok netswitch.vlan-entry-define\n");
+        return;
+    }
+
+    if (hop_word(&line, "netswitch.vlan-member-define")) {
+        if (line[0] == '\0') {
+            io_say("usage: netswitch.vlan-member-define <mc-index> <vid> <ports>\n");
+            io_say("define a memberconfig entry to tag incoming untagged traffic\n");
+            return;
+        }
+        uint16_t mc = parse_number(&line);
+        uint16_t vid = parse_number(&line);
+        uint16_t ports = parse_number(&line);
+
+        nsw_mc_set(mc, vid, ports);
+        for (uint8_t p = 0; p < 5; p++) {
+            if ((ports & (1 << p)) > 0) {
+                nsw_port_set_mc(mc, p);
+            }
+        }
+        io_say("ok netswitch.vlan-member-define\n");
+        return;
+    }
+
+    if (hop_word(&line, "netswitch.vlan-filtering")) {
+        if (line[0] == '\0') {
+            io_say("usage: netswitch.vlan-filtering <port> <tagged-only|untagged-only|all>\n");
+            io_say("configure filter to drop tagged or untagged traffic on port\n");
+            return;
+        }
+        uint16_t port = parse_number(&line);
+        if (hop_word(&line, "tagged-only")) {
+            nsw_port_vlan_filtering(port, PORT_ACCEPT_TAGGED_ONLY);
+        }
+        else if (hop_word(&line, "untagged-only")) {
+            nsw_port_vlan_filtering(port, PORT_ACCEPT_UNTAGGED_ONLY);
+        }
+        else if (hop_word(&line, "all")) {
+            nsw_port_vlan_filtering(port, PORT_ACCEPT_ALL);
+        }
+        else {
+            io_say("fail unknown mode\n");
+        }
+        io_say("ok netswitch.vlan-filtering\n");
         return;
     }
 

--- a/hardware/firmware/box_rp2040/src/network_switch/network_switch_status_reader.c
+++ b/hardware/firmware/box_rp2040/src/network_switch/network_switch_status_reader.c
@@ -657,6 +657,13 @@ nsw_config_vlans(bool enable) {
     return true;
 }
 
+bool
+nsw_config_is_vlans_enabled() {
+    uint32_t reg;
+    smi_read(REG_VLAN_CONTROL, &reg);
+    return reg & 1;
+}
+
 uint16_t
 nsw_link_speed_mbps(nsw_port_regs_t *regs) {
     if ((regs->bmcr & MII_BMCR_AUTONEG_ENABLE) && (regs->bmsr & MII_BMSR_AUTONEG_COMPLETE)) {

--- a/hardware/firmware/box_rp2040/src/network_switch/network_switch_status_reader.h
+++ b/hardware/firmware/box_rp2040/src/network_switch/network_switch_status_reader.h
@@ -49,6 +49,7 @@ void nsw_dump_member_config();
 void nsw_dump_pvids();
 
 bool nsw_config_vlans(bool enable);
+bool nsw_config_is_vlans_enabled();
 bool nsw_vlan_set(nsw_vlan_cfg_t *cfg);
 bool nsw_vlan_get(vlan_id_t vid, nsw_vlan_cfg_t *cfg);
 

--- a/software/video-status/.gitignore
+++ b/software/video-status/.gitignore
@@ -1,0 +1,165 @@
+### Python template
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/latest/usage/project/#working-with-version-control
+.pdm.toml
+.pdm-python
+.pdm-build/
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/
+
+

--- a/software/video-status/setup.py
+++ b/software/video-status/setup.py
@@ -1,0 +1,13 @@
+from setuptools import setup
+
+setup(name='video_status',
+      version='1',
+      description='Daemon for updating the status on the video box display',
+      url='https://github.com/FOSDEM/video',
+      packages=['video_status'],
+      install_requires=[
+          'pyserial',
+      ],
+      entry_points={
+          'console_scripts': ['video-status=video_status.__main__:main'],
+      })

--- a/software/video-status/switch.toml
+++ b/software/video-status/switch.toml
@@ -1,0 +1,13 @@
+# Example config for switch vlans
+vlans = true
+
+[wan]
+vlan = 10
+tagged = ["IN"]
+untagged = ["01"]
+
+[lan]
+vlan = 11
+tagged = ["IN"]
+untagged = ["02", "03", "04"]
+

--- a/software/video-status/video_status/__main__.py
+++ b/software/video-status/video_status/__main__.py
@@ -1,0 +1,487 @@
+#!/usr/bin/env python3
+
+import json
+import os
+import re
+import signal
+import subprocess
+import sys
+import syslog
+import time
+import tomllib
+
+import serial
+
+WHITE = 255, 255, 255
+BLACK = 0, 0, 0
+GREEN = 0, 255, 0
+RED = 255, 0, 0
+
+NORMAL = 0
+GOOD = 1
+BAD = 2
+CHECK = 3
+
+os.environ["LANG"] = "C"
+
+LOGO_FILE = '/usr/local/bin/logo.png'
+
+portnames = ["IN", "01", "02", "03", "04"]
+
+
+class stateEntry():
+    """ entry in the states """
+    data: str
+    nl: bool
+    state: int  # 0 NORMAL 1 GOOD(green) 2 BAD(red) 3 CHECK(yellow)
+
+    def __init__(self, inpdata, inpstate=0, nl=True):
+        self.data = inpdata
+        self.state = inpstate
+        self.nl = nl
+
+
+def port_name_to_idx(name):
+    for i, n in enumerate(portnames):
+        if n == name:
+            return i
+
+
+def configure_switch():
+    with get_serial() as port:
+        if not os.path.isfile("/etc/network/switch.toml"):
+            syslog.syslog("No switch config file found, disabling vlan support")
+            port.write(b"netswitch.vlan-init 0\n")
+            return
+    with open("/etc/network/switch.toml", "rb") as handle:
+        config = tomllib.load(handle)
+
+    with get_serial() as port:
+        port.write(b"netswitch.vlan-init 0\n")
+
+        if not config['vlans']:
+            syslog.syslog("VLAN support is disabled in the config")
+            return
+
+        port.write(b"netswitch.vlan-init 1\n")
+
+        memberconfig = 1
+        all_tagged = set()
+        all_untagged = set()
+        for vlan_name in config:
+            if not isinstance(config[vlan_name], dict):
+                continue
+
+            vlan = config[vlan_name]
+
+            vid = vlan['vlan']
+            members = 0
+            tagged = 0
+            untagged = 0
+            syslog.syslog(f"Creating vlan '{vlan_name}' with vid {vid}")
+
+            for p in vlan['tagged']:
+                members |= 1 << port_name_to_idx(p)
+                tagged |= 1 << port_name_to_idx(p)
+                all_tagged.add(p)
+            for p in vlan['untagged']:
+                members |= 1 << port_name_to_idx(p)
+                untagged |= 1 << port_name_to_idx(p)
+                all_untagged.add(p)
+            print(f"VLAN {vid} tagged {tagged} untagged {untagged} members {members}")
+
+            port.write(f"netswitch.vlan-entry-define {vid} {members} {untagged}\n".encode())
+
+            if untagged != 0:
+                port.write(f"netswitch.vlan-member-define {memberconfig} {vid} {untagged}\n".encode())
+                print(f"netswitch.vlan-member-define {memberconfig} {vid} {untagged}\n".encode())
+                memberconfig += 1
+
+        for p in all_tagged - all_untagged:
+            port.write(f"netswitch.vlan-filtering {port_name_to_idx(p)} tagged-only\n".encode())
+        for p in all_untagged - all_tagged:
+            port.write(f"netswitch.vlan-filtering {port_name_to_idx(p)} untagged-only\n".encode())
+        for p in all_tagged & all_untagged:
+            port.write(f"netswitch.vlan-filtering {port_name_to_idx(p)} all\n".encode())
+
+
+def render_text(states):
+    def strRed(skk):
+        return "\033[91m" + skk + "\033[00m"
+
+    def strGreen(skk):
+        return "\033[92m" + skk + "\033[00m"
+
+    def strYellow(skk):
+        return "\033[93m" + skk + "\033[00m"
+
+    out = ""
+
+    maxLen = 0
+
+    for state in states:
+        maxLen = max(maxLen, len(state.data))
+
+    maxLen = int(maxLen / 8 + 1) * 8
+    cline = "| "
+    for state in states:
+        if state.state == GOOD:
+            rend = strGreen(state.data)
+        elif state.state == BAD:
+            rend = strRed(state.data)
+        elif state.state == CHECK:
+            rend = strYellow(state.data)
+        else:
+            rend = state.data
+
+        cline += rend
+        if state.nl:
+            out += cline + " " * (maxLen - len(cline)) + " |\n"
+            cline = "| "
+
+    return out
+
+
+def render_commands(states):
+    def strRed(skk):
+        return b"\x1b\x01" + skk.encode("utf8")
+
+    def strGreen(skk):
+        return b"\x1b\x0e" + skk.encode("utf8")
+
+    def strYellow(skk):
+        return b"\x1b\x03" + skk.encode("utf8")
+
+    def strWhite(skk):
+        return b"\x1b\x0f" + skk.encode("utf8")
+
+    out = b"\n\n"
+    out += b"display.img.clear\n"
+
+    line = 0
+
+    cline = b""
+    for state in states:
+        if state.state == GOOD:
+            rend = strGreen(state.data)
+        elif state.state == BAD:
+            rend = strRed(state.data)
+        elif state.state == CHECK:
+            rend = strYellow(state.data)
+        else:
+            rend = strWhite(state.data)
+        cline += rend
+        if state.nl:
+            out += b"display.text.line " + str(line).encode("utf8") + b" " + cline + b"                 \n"
+            line += 1
+            cline = b""
+
+    out += b"display.refresh\n"
+    # print(out)
+    return out
+
+
+def get_serial():
+    while True:
+        try:
+            s = serial.Serial('/dev/tty_fosdem_box_ctl', 115200, timeout=1, exclusive=True)
+        except:
+            continue
+        break
+
+    return s
+
+
+def output_terminal(states):
+    sys.stdout.write("\x1b7\x1b[%d;%df%s\x1b8" % (0, 0, render_text(states)))
+    sys.stdout.flush()
+
+
+def clear_serial_display():
+    with get_serial() as port:
+        port.write(b"display.text.clear")
+
+
+def output_serial_display(states):
+    cmds = render_commands(states)
+    with get_serial() as port:
+        port.write(cmds)
+
+
+img_x = 240
+img_y = 134
+xpos = int((img_x - img_y) / 2)
+
+
+def output_image():
+    try:
+        f = open("/tmp/picture.raw", "rb");
+        data = f.read()
+        f.close()
+        l = len(data)
+        expected = img_x * img_y * 2
+        if l != expected:
+            syslog(f"/tmp/picture.raw has size {l} bytes expected {expected} bytes")
+            return
+    except:
+        return
+
+    with get_serial() as port:
+        port.write(b"display.text.clear\n")
+        port.write(b"display.img.clear\n")
+
+        dcmd = f"display.img 565 0 {xpos} {img_x} {img_y}\n"
+        port.write(dcmd.encode("utf-8"))
+        port.write(data)
+        port.write(b"\ndisplay.imgonly\n")
+
+
+switch_state = [None, None, None, None, None]
+
+
+def start_chargers():
+    with get_serial() as port:
+        port.write(b"pb.chargers.on 1\n")
+
+
+def read_switch():
+    ret = [None, None, None, None, None]
+
+    updated = False
+    with get_serial() as port:
+        port.write(b"netswitch.info\n")
+        while True:
+            line = port.readline().decode("utf-8").strip()
+            m = re.match(r"port ([0-9]): (.*)$", line)
+            if m is not None:
+                p = int(m.group(1))
+                s = m.group(2)
+                ret[p] = s
+                updated = True
+            elif re.match(r"^(ok|fail) ", line):
+                break
+
+    if not updated:
+        return None
+    else:
+        try:
+            with open("/tmp/netstate.tmp", "w") as f:
+                f.write(json.dumps(switch_state))
+
+            os.rename("/tmp/netstate.tmp", "/tmp/netstate.json")
+        except:
+            pass
+
+        return ret
+
+
+def update_switch_state():
+    new_state = read_switch()
+
+    if new_state is None:
+        return
+
+    for i in range(0, 5):
+        if new_state[i] != switch_state[i]:
+            syslog.syslog(f"Port {i} state change {switch_state[i]} -> {new_state[i]}")
+            switch_state[i] = new_state[i]
+
+
+diag = ''
+
+
+def update_diag():
+    global diag
+    newdiag = ''
+    with get_serial() as port:
+        port.write(b"status\n")
+        while True:
+            line = port.readline().decode("utf-8").strip()
+            if re.match(r"^(ok|fail) ", line):
+                break
+            newdiag += "\n" + line
+
+    if diag != newdiag:
+        diag = newdiag
+    else:
+        try:
+            with open("/tmp/status.tmp", "w") as f:
+                f.write(diag)
+
+            os.rename("/tmp/status.tmp", "/tmp/status.txt")
+        except:
+            pass
+
+
+def main():
+    signal.signal(signal.SIGHUP, signal_handler)
+
+    counter = 0
+    configure_switch()
+
+    os.system("clear")
+    syslog.openlog("video-status")
+    update_switch_state()
+    start_chargers()
+
+    while True:
+        info = update_sysinfo()
+        update_switch_state()
+        update_diag()
+        output_terminal(info)
+        if counter % 3 == 0:
+            output_serial_display(info)
+        else:
+            output_image()
+        counter = (counter + 1) % 256
+        time.sleep(1)
+
+
+def update_sysinfo():
+    ret = []
+    # Hostname
+    hostname = os.popen('hostname -s').read().strip()
+
+    # Uptime
+    uptime = os.popen('uptime').read().strip()
+    matches = re.search(
+        '\s?(.*)\s+up\s+(.*?),\s+([0-9]+) users?,\s+load average: ([0-9]+\.[0-9][0-9]),?\s+([0-9]+\.[0-9][0-9]),?\s+([0-9]+\.[0-9][0-9])',
+        uptime)
+    uptime_time, uptime_duration, uptime_users, uptime_avg1, uptime_avg5, uptime_avg15 = matches.groups()
+
+    # Interface
+
+    try:
+        ifdata = json.loads(
+            subprocess.check_output("ip -j route get 8.8.8.8", shell=True, stderr=subprocess.DEVNULL).decode("utf-8"))
+        interface = ifdata[0]["dev"]
+        # IP addresses
+        addr_data = json.loads(
+            subprocess.check_output(f"ip -j addr show dev {interface} primary scope global", shell=True,
+                                    stderr=subprocess.DEVNULL).decode("utf-8"))
+        ip_link_mac = addr_data[0]["address"]
+
+        ip_prefix_v4 = False
+        ip_addr_v4 = False
+
+        for a in addr_data[0]["addr_info"]:
+            try:
+                if a["family"] == "inet":
+                    ip_prefix_v4 = str(a["local"]) + "/" + str(a["prefixlen"])
+                    ip_addr_v4 = str(a["local"])
+            except KeyError:
+                pass
+
+    except:
+        interface = None
+        ip_prefix_v4 = False
+        ip_addr_v4 = False
+        ip_link_mac = "UNKNOWN"
+
+    # Signal
+    # width: 1920
+    # height: 1200
+    # signal: no
+
+    try:
+        signaldata = json.loads(open('/tmp/ms213x-status', 'r').read())
+        if signaldata['signal'] == 'yes':
+            signal = True
+            resX = signaldata['width']
+            resY = signaldata['height']
+            resolution = f"{resX}x{resY}"
+        else:
+            signal = False
+    except Exception as e:
+        #		print("exception")
+        #		print(e)
+        signal = False
+    # print(signaldata)
+    if not os.path.isfile("/tmp/ms213x-status"):
+        ret.append(stateEntry("NO CAPTURE DEVICE", BAD))
+    elif signal:
+        ret.append(stateEntry(f"SIGNAL {resolution}"))
+    else:
+        ret.append(stateEntry("NO SIGNAL", BAD))
+
+    ret.append(stateEntry(f"host: {hostname} ", nl=False))
+
+    rec_info = os.popen('systemctl show video-recorder --property=ActiveState').read()
+    if re.search('^ActiveState=active', rec_info) == None:
+        ret.append(stateEntry(f"rec: paused ", BAD))
+    else:
+        ret.append(stateEntry(f"rec: RECORD ", GOOD))
+
+    try:
+        swstate = json.loads(open('/tmp/netstate.json', 'r').read())
+        n = 0
+        ret.append(stateEntry("Switch:", NORMAL, nl=False))
+        for p in swstate:
+            pn = portnames[n]
+            if p == "down":
+                ret.append(stateEntry(f"{pn}", BAD, nl=False))
+            elif p == "up full-duplex 1000mbps":
+                ret.append(stateEntry(f"{pn}", GOOD, nl=False))
+            else:
+                ret.append(stateEntry(f"{pn}", CHECK, nl=False))
+            ret.append(stateEntry("|", NORMAL, nl=False))
+            n += 1
+        ret.append(stateEntry(""))
+    except:
+        ret.append(stateEntry("Switch not found", BAD))
+
+    connected = subprocess.check_output("ss -H -o state established '( sport = :8899 )'  not dst '[::1]'|wc -l",
+                                        shell=True).strip().decode("utf-8")
+
+    ret.append(stateEntry(f"connected readers: {connected}", GOOD if int(connected) > 0 else NORMAL))
+
+    sensordata = json.loads(subprocess.check_output("sensors -j 2>/dev/null", shell=True).decode("utf-8"))
+
+    # root@box1:/usr/local/bin# sensors -j 2>/dev/null | jq '."thinkpad-isa-0000".temp1.t:semp1_input' |less
+    # root@box1:/usr/local/bin# sensors -j 2>/dev/null | jq '."coretemp-isa-0000"."Package id 0"."temp1_input"'
+    state = NORMAL
+    cpu_temp = sensordata["coretemp-isa-0000"]["Package id 0"]["temp1_input"]
+    if os.path.exists("/sys/devices/system/cpu/cpu0/cpufreq/scaling_cur_freq"):
+        fp = open('/sys/devices/system/cpu/cpu0/cpufreq/scaling_cur_freq', "r")
+        hz = int(int(fp.read().rstrip()) / 1000)
+        fp.close()
+        if hz > 1800:
+            state = NORMAL
+        else:
+            state = BAD
+    else:
+        if cpu_temp > 80:
+            state = BAD
+        else:
+            state = NORMAL
+
+    ret.append(stateEntry(f"cpu t:{cpu_temp}|f:{hz} MHz", state))
+
+    ret.append(
+        stateEntry(f"load: {uptime_avg1} {uptime_avg5} {uptime_avg15}", NORMAL if float(uptime_avg1) < 3.9 else BAD))
+
+    if ip_addr_v4 != False:
+        ret.append(stateEntry(f"IPv4: {ip_prefix_v4}"))
+        ret.append(stateEntry(f"MAC: {ip_link_mac}"))
+    else:
+        ret.append(stateEntry(f"IPv4: no IPv4 address", BAD))
+        ret.append(stateEntry(f"MAC: {ip_link_mac}"))
+
+    if os.path.exists('/etc/fosdem_revision'):
+        fp = open('/etc/fosdem_revision', "r")
+        ret.append(stateEntry(fp.read().rstrip()))
+        fp.close()
+    else:
+        ret.append(stateEntry("revision not found"), BAD)
+
+    return ret
+
+
+def signal_handler(signum, frame):
+    # We need something to catch signals since systemd sends a SIGHUP, if we
+    # don't catch that, we'll quit and die
+    pass
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Adds the serial port commands to debug and configure vlans in the switch.

To actually use this I added this function to `video-status.py` which is not the ideal place for this:

```python
def configure_switch():
    with get_serial() as port:
        if not os.path.isfile("/etc/network/switch.toml"):
            syslog.syslog("No switch config file found, disabling vlan support")
            port.write(b"netswitch.vlan-init 0\n")
            return
    with open("/etc/network/switch.toml", "rb") as handle:
        config = tomllib.load(handle)

    with get_serial() as port:
        port.write(b"netswitch.vlan-init 0\n")

        if not config['vlans']:
            syslog.syslog("VLAN support is disabled in the config")
            return

        port.write(b"netswitch.vlan-init 1\n")

        memberconfig = 1
        all_tagged = set()
        all_untagged = set()
        for vlan_name in config:
            if not isinstance(config[vlan_name], dict):
                continue

            vlan = config[vlan_name]

            vid = vlan['vlan']
            members = 0
            tagged = 0
            untagged = 0
            syslog.syslog(f"Creating vlan '{vlan_name}' with vid {vid}")

            for p in vlan['tagged']:
                members |= 1 << port_name_to_idx(p)
                tagged |= 1 << port_name_to_idx(p)
                all_tagged.add(p)
            for p in vlan['untagged']:
                members |= 1 << port_name_to_idx(p)
                untagged |= 1 << port_name_to_idx(p)
                all_untagged.add(p)
            print(f"VLAN {vid} tagged {tagged} untagged {untagged} members {members}")

            port.write(f"netswitch.vlan-entry-define {vid} {members} {untagged}\n".encode())

            if untagged != 0:
                port.write(f"netswitch.vlan-member-define {memberconfig} {vid} {untagged}\n".encode())
                print(f"netswitch.vlan-member-define {memberconfig} {vid} {untagged}\n".encode())
                memberconfig += 1

        for p in all_tagged - all_untagged:
            port.write(f"netswitch.vlan-filtering {port_name_to_idx(p)} tagged-only\n".encode())
        for p in all_untagged - all_tagged:
            port.write(f"netswitch.vlan-filtering {port_name_to_idx(p)} untagged-only\n".encode())
        for p in all_tagged & all_untagged:
            port.write(f"netswitch.vlan-filtering {port_name_to_idx(p)} all\n".encode())
```

This allows configuration with a file in `/etc/network/switch.toml`:

```toml
vlans = true

[wan]
vlan = 10
tagged = ["IN"]
untagged = ["01"]

[lan]
vlan = 11
tagged = ["IN"]
untagged = ["02", "03", "04"]
```